### PR TITLE
Add cuCIM io module

### DIFF
--- a/cubic/cucim/__init__.py
+++ b/cubic/cucim/__init__.py
@@ -1,0 +1,5 @@
+"""cuCIM compatibility helpers."""
+
+from . import io
+
+__all__ = ["io"]

--- a/cubic/cucim/io.py
+++ b/cubic/cucim/io.py
@@ -1,0 +1,29 @@
+"""Compatibility layer for ``skimage.io`` with optional GPU support."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+from skimage import io as skio
+
+from ..cuda import asnumpy, to_device
+
+
+def imread(fname: str | bytes, *, device: str = "CPU", **kwargs: Any) -> np.ndarray:
+    """Read image from ``fname`` into ``device`` memory."""
+    img = skio.imread(fname, **kwargs)
+    if device.upper() == "GPU":
+        return to_device(img, "GPU")
+    return np.asarray(img)
+
+
+def imsave(fname: str | bytes, arr: np.ndarray, **kwargs: Any) -> None:
+    """Save ``arr`` to ``fname`` using CPU-based ``skimage`` IO."""
+    cpu_arr = asnumpy(arr)
+    skio.imsave(fname, cpu_arr, **kwargs)
+
+
+def imwrite(fname: str | bytes, arr: np.ndarray, **kwargs: Any) -> None:
+    """Alias for :func:`imsave`."""
+    imsave(fname, arr, **kwargs)

--- a/cubic/skimage.py
+++ b/cubic/skimage.py
@@ -25,16 +25,21 @@ class SkimageProxy(ModuleType):
             return self.__dict__[func_name]
 
         def func_wrapper(*args: Any, **kwargs: Any) -> Any:
-            """Wrap skimage or cucim.skimage function based on device capability."""
-            array = args[0] if args else kwargs.get("image", None)
+            """Wrap skimage or cucim functions based on device capability."""
             base_module = "skimage"
 
-            if self.cp is not None and hasattr(array, "device"):
-                device_val = getattr(array, "device", None)
-                if hasattr(device_val, "id") or (
-                    isinstance(device_val, str) and device_val != "cpu"
-                ):
-                    base_module = "cucim.skimage"
+            if self.__name__ == "io":
+                base_module = "cubic.cucim"
+                array = args[1] if len(args) > 1 else kwargs.get("arr", None)
+            else:
+                array = args[0] if args else kwargs.get("image", None)
+
+                if self.cp is not None and hasattr(array, "device"):
+                    device_val = getattr(array, "device", None)
+                    if hasattr(device_val, "id") or (
+                        isinstance(device_val, str) and device_val != "cpu"
+                    ):
+                        base_module = "cucim.skimage"
 
             full_func_name = f"{base_module}.{self.__name__}.{func_name}"
             module_name, method_name = full_func_name.rsplit(".", maxsplit=1)

--- a/tests/test_cucim_io.py
+++ b/tests/test_cucim_io.py
@@ -1,0 +1,30 @@
+"""Tests for cuCIM IO wrapper."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+import cubic.skimage as mc_skimage
+from cubic.cuda import ascupy, asnumpy
+
+
+@pytest.mark.parametrize("use_gpu", [False, True])
+def test_io_roundtrip(tmp_path, use_gpu: bool, gpu_available: bool) -> None:
+    """Write and read an image using the IO proxy."""
+    img = np.random.randint(0, 255, (4, 4), dtype=np.uint8)
+    if use_gpu:
+        if not gpu_available:
+            pytest.skip("GPU not available")
+        data = ascupy(img)
+    else:
+        data = img
+
+    fname = tmp_path / "img.png"
+    mc_skimage.io.imsave(fname, data)
+    result = mc_skimage.io.imread(fname, device="GPU" if use_gpu else "CPU")
+
+    if use_gpu:
+        assert np.allclose(asnumpy(result), img)
+    else:
+        assert np.allclose(result, img)


### PR DESCRIPTION
## Summary
- introduce `cubic.cucim.io` with GPU-aware `imread` and `imsave` helpers
- route `cubic.skimage.io` calls through the new module
- test reading and writing on CPU and GPU

## Testing
- `ruff check .`
- `mypy --ignore-missing-imports cubic/`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883ff20a7188330ba2513a827918829

## Summary by Sourcery

Introduce a GPU-aware IO compatibility layer by adding the cubic.cucim.io module and routing skimage.io calls through it for optional GPU support, and add tests for image read/write roundtrips on both CPU and GPU.

New Features:
- Add cubic.cucim.io module with GPU-aware imread, imsave, and imwrite functions
- Route cubic.skimage.io calls through the new module to enable automatic CPU/GPU dispatch

Enhancements:
- Adjust cubic.skimage __getattr__ logic to delegate IO methods to the GPU-compatible module when appropriate

Tests:
- Add tests for CPU and GPU image IO roundtrips using the new IO proxy